### PR TITLE
docs(index): redirect to about page on index page

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,0 +1,3 @@
++++
+redirect_to = "about"
++++


### PR DESCRIPTION
instead of showing a blank page when you load the index, this will show the about page content by default