### PR TITLE
docs(variables): note the existence of the _exec_status variable

### DIFF
--- a/content/rules/variables.md
+++ b/content/rules/variables.md
@@ -9,6 +9,7 @@ The below variables are set by default:
 ${_raw_http_output} raw output from an HTTP request action.
 ${_raw_http_status} response code from an HTTP request action.
 ${_exec_output} stdout output from an exec action.
+${_exec_status} the status code from an exec action.
 ${_raw_user_input} raw message from a user captured by the bot when a match is found.
 ${_user.email} email of user that sent a message that triggered a match.
 ${_user.firstname} first name of user that sent a message that triggered a match.


### PR DESCRIPTION
@wass3r - I also noted that https://github.com/target/flottbot-docs/pull/26/files#diff-86afe5082dd07aa4370d358fb7878520R22 doesn't make much sense currently. Do you remember what you meant by that comment?