### PR TITLE
docs: add limit_to_rooms info

### DIFF
--- a/content/actions/log.md
+++ b/content/actions/log.md
@@ -14,6 +14,6 @@ actions:
   - name: trigger log
     type: log
     message: "${_user.firstname} ${_user.lastname} is talking about breakfast."
-    limit_to_rooms:
+    output_to_rooms:
       - bot-log
 ```

--- a/content/actions/message.md
+++ b/content/actions/message.md
@@ -14,6 +14,6 @@ actions:
   - name: trigger message
     type: message
     message: "This is a message from your bot."
-    limit_to_rooms:
+    output_to_rooms:
       - general
 ```

--- a/content/rules/anatomy.md
+++ b/content/rules/anatomy.md
@@ -51,6 +51,9 @@ ignore_threads: true # will prevent the rule from triggering inside threaded mes
 
 direct_message_only: false # will only reply via direct message if enabled
 
+limit_to_rooms: # this is an array of rooms/channels where the rule can get triggered.
+  - coolchannel
+
 output_to_rooms: # this is an array of rooms/channels you want messages to be sent into in Slack.
   - mychannel
 
@@ -80,6 +83,7 @@ include_in_help: true # see help_text in help message
 * **start_message_thread** (_boolean_) If set to true, the bot start a thread with your trigger message being the parent. Otherwise, the bot will post a message in the same channel.
 * **ignore_threads** (_boolean_) If set to true, the bot will not be able to get triggered for this rule from within a message a thread.
 * **direct_message_only** (_boolean_) If set to true, the bot will never respond to this rule in a room it will only direct message the sender.
+* **limit_to_rooms** (_yaml array_) An array of rooms where the rule can get triggered.
 * **output_to_rooms** (_yaml array_) An array of rooms you want messages to be sent into.
 * **output_to_users** (_yaml array_) An array of specific users you want messages to be to.
 * **help_text** (_string_) This is the response we show to the user when they interact with the bot and no match occurs. We often like to put bot usage instructions for the rule here.


### PR DESCRIPTION
For https://github.com/target/flottbot/pull/184

Adds some docs in line with the existing entry to cover the addition of `limit_to_rooms` at a rule level.

Additionally, it changes the reference to `limit_to_rooms` at an action level to `output_to_rooms` instead.